### PR TITLE
Better error handling

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -2,17 +2,22 @@ import gulp from 'gulp'
 import babel from 'gulp-babel'
 import watch from 'gulp-watch'
 import rename from 'gulp-rename'
+import gutil from 'gulp-util'
 import path from 'path'
 import { exec } from 'child_process'
 
 const compile = () => {
   gulp.src('components/**.js')
     .pipe(babel())
+    .on('error', gutil.log)
     .pipe(gulp.dest('lib'))
     .on('end', () => exec(
       './node_modules/.bin/mjml index.mjml',
-      () => console.log('> MJML compilation finished'))
-    )
+      (error, stdout) => {
+        console.log(stdout)
+        console.log('> MJML compilation finished')
+      }
+    ))
 }
 
 gulp.task('build', compile)


### PR DESCRIPTION
There was 2 problems about errors : 

- When working on a component one error would crash the `watch`. 
- When working on an MJML file, no errors were displayed making the code hard to debug.