### PR TITLE
change way of registering dependencies, for better handle with mjmlconfig

### DIFF
--- a/components/MjBasicComponent.js
+++ b/components/MjBasicComponent.js
@@ -1,13 +1,4 @@
-import { registerDependencies } from 'mjml-validator'
 import { BodyComponent } from 'mjml-core'
-
-registerDependencies({
-  // Tell the validator which tags are allowed as our component's parent
-  'mj-hero': ['mj-basic-component'],
-  'mj-column': ['mj-basic-component'],
-  // Tell the validator which tags are allowed as our component's children
-  'mj-basic-component': []
-})
 
 /*
   Our component is a (useless) simple text tag, that adds colored stars around the text.
@@ -16,6 +7,14 @@ registerDependencies({
 export default class MjBasicComponent extends BodyComponent {
   // Tell the parser that our component won't contain other mjml tags
   static endingTag = true
+  
+  static dependencies = {
+    // Tell the validator which tags are allowed as our component's parent
+    'mj-hero': ['mj-basic-component'],
+    'mj-column': ['mj-basic-component'],
+    // Tell the validator which tags are allowed as our component's children
+    'mj-basic-component': []
+  }
 
   // Tells the validator which attributes are allowed for mj-layout
   static allowedAttributes = {

--- a/components/MjImageText.js
+++ b/components/MjImageText.js
@@ -1,16 +1,16 @@
 import reverse from 'lodash/reverse'
 
-import { registerDependencies } from 'mjml-validator'
 import { BodyComponent } from 'mjml-core'
-registerDependencies({
-  'mj-image-text': [],
-  'mj-body': ['mj-image-text'],
-  'mj-wrapper': ['mj-image-text'],
-})
 
 export default class MjImageText extends BodyComponent {
   static endingTag = true
 
+  static dependencies = {
+    'mj-image-text': [],
+    'mj-body': ['mj-image-text'],
+    'mj-wrapper': ['mj-image-text'],
+  }
+  
   /*
     We could obviously handle all the attributes accepted for Mj Section,
     Column, Image and Text, but let's keep it simple for this example.

--- a/components/MjLayout.js
+++ b/components/MjLayout.js
@@ -1,26 +1,4 @@
-import { registerDependencies } from 'mjml-validator'
 import { BodyComponent } from 'mjml-core'
-
-registerDependencies({
-  // Tell the validator which tags are allowed as our component's children
-  'mj-layout': [
-    'mj-accordion',
-    'mj-button',
-    'mj-carousel',
-    'mj-divider',
-    'mj-html',
-    'mj-image',
-    'mj-raw',
-    'mj-social',
-    'mj-spacer',
-    'mj-table',
-    'mj-text',
-    'mj-navbar'
-  ],
-  // Now tell the validator which tags are allowed as our component's parent
-  'mj-wrapper': ['mj-layout'],
-  'mj-body': ['mj-layout'],
-})
 
 /*
   This component is an example of layout, which uses existing mjml components
@@ -31,6 +9,27 @@ export default class MjLayout extends BodyComponent {
   constructor(initialDatas = {}) {
     super(initialDatas)
     this.cssId = Math.floor(Math.random() * 9) + 1
+  }
+  
+  static dependencies = {
+    // Tell the validator which tags are allowed as our component's children
+    'mj-layout': [
+      'mj-accordion',
+      'mj-button',
+      'mj-carousel',
+      'mj-divider',
+      'mj-html',
+      'mj-image',
+      'mj-raw',
+      'mj-social',
+      'mj-spacer',
+      'mj-table',
+      'mj-text',
+      'mj-navbar'
+    ],
+    // Now tell the validator which tags are allowed as our component's parent
+    'mj-wrapper': ['mj-layout'],
+    'mj-body': ['mj-layout'],
   }
 
   // Tells the validator which attributes are allowed for mj-layout


### PR DESCRIPTION
Dependencies could not be registered on the right instance of mjml-validator.

i.e. if using this boilerplate, adding new components, then in mjml-app target the .mjmlconfig from this project.
the instance of mjml-validator imported for registerDependencies is not the one that is used by mjml-app.
Using `static dependencies = ` in the component ensures it will be registered by the right instance.