### PR TITLE
Fix Error: Cannot find module ../lib\MjBasicComponent.js

### DIFF
--- a/.mjmlconfig
+++ b/.mjmlconfig
@@ -1,7 +1,7 @@
 {
   "packages": [
-    "./lib/MjBasicComponent.js",
-    "./lib/MjImageText.js",
-    "./lib/MjLayout.js"
+    "./lib/compponents/MjBasicComponent.js",
+    "./lib/compponents/MjImageText.js",
+    "./lib/compponents/MjLayout.js"
   ]
 }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -8,7 +8,7 @@ import mjml2html from 'mjml'
 import { registerComponent } from 'mjml-core'
 
 const walkSync = (dir, filelist = []) => {
-  fs.readdirSync(dir).forEach(file => {
+  fs.readdirSync(dir).forEach((file) => {
     filelist = fs.statSync(path.join(dir, file)).isDirectory()
       ? walkSync(path.join(dir, file), filelist)
       : filelist.concat(path.join(dir, file))
@@ -21,14 +21,16 @@ const watchedComponents = walkSync('./components')
 const compile = () => {
   return gulp
     .src(path.normalize('components/**/*.js'))
-    .pipe(babel({
-      presets: ['@babel/preset-env'],
-    }))
+    .pipe(
+      babel({
+        presets: ['@babel/preset-env'],
+      }),
+    )
     .on('error', log)
     .pipe(gulp.dest('lib'))
     .on('end', () => {
-      watchedComponents.forEach(compPath => {
-        const fullPath = path.join(process.cwd(), compPath.replace(/^components/, 'lib'))
+      watchedComponents.forEach((compPath) => {
+        const fullPath = path.join(process.cwd(), compPath.replace('/^components/', 'lib'))
         delete require.cache[fullPath]
         registerComponent(require(fullPath).default)
       })


### PR DESCRIPTION
Fix to the following error:

`> gulp watch

[15:47:17] Requiring external module @babel/register
Missing or unreadable custom component :  ./lib/MjBasicComponent.js
Missing or unreadable custom component :  ./lib/MjImageText.js
Missing or unreadable custom component :  ./lib/MjLayout.js
[15:47:19] Using gulpfile D:\dev\projects\assist\workspace\assist\src\main\resources\templates\mail\mjml\mjml-component-boilerplate\gulpfile.babel.js
[15:47:19] Starting 'watch'...
[15:47:19] 'watch' errored after 391 ms
[15:47:19] Error: Cannot find module 'D:\dev\projects\assist\workspace\assist\src\main\resources\templates\mail\mjml\mjml-component-boilerplate\lib\MjBasicComponent.js'
Require stack:
- D:\dev\projects\assist\workspace\assist\src\main\resources\templates\mail\mjml\mjml-component-boilerplate\gulpfile.babel.js
- D:\dev\projects\assist\workspace\assist\src\main\resources\templates\mail\mjml\mjml-component-boilerplate\node_modules\gulp\node_modules\gulp-cli\lib\shared\require-or-import.js
- D:\dev\projects\assist\workspace\assist\src\main\resources\templates\mail\mjml\mjml-component-boilerplate\node_modules\gulp\node_modules\gulp-cli\lib\versioned\^4.0.0\index.js
- D:\dev\projects\assist\workspace\assist\src\main\resources\templates\mail\mjml\mjml-component-boilerplate\node_modules\gulp\node_modules\gulp-cli\index.js
- D:\dev\projects\assist\workspace\assist\src\main\resources\templates\mail\mjml\mjml-component-boilerplate\node_modules\gulp\bin\gulp.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:92:18)
    at forEach (D:\dev\projects\assist\workspace\assist\src\main\resources\templates\mail\mjml\mjml-component-boilerplate\/gulpfile.babel.js:33:27)
    at Array.forEach (<anonymous>)
    at Pumpify.<anonymous> (D:\dev\projects\assist\workspace\assist\src\main\resources\templates\mail\mjml\mjml-component-boilerplate\/gulpfile.babel.js:30:25)
    at Pumpify.emit (events.js:387:35)
    at Pumpify.emit (domain.js:532:15)
    at endReadableNT (D:\dev\projects\assist\workspace\assist\src\main\resources\templates\mail\mjml\mjml-component-boilerplate\node_modules\readable-stream\lib\_stream_readable.js:101
0:12)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! test@1.0.1 start: `gulp watch`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the test@1.0.1 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
`